### PR TITLE
Fixing address number caracters limit

### DIFF
--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -213,7 +213,7 @@ class FecharPreListaDePostagem
         $writer->writeCdata($this->_($destinatario->getComplemento(), 30));
         $writer->endElement();
         $writer->startElement('numero_end_destinatario');
-        $writer->writeCdata($this->_($destinatario->getNumero(), 6));
+        $writer->writeCdata($this->_($destinatario->getNumero(), 5));
         $writer->endElement();
         $writer->endElement();
     }


### PR DESCRIPTION
Change caracters limist from 6 to 5 for `numero_end_destinatario` like correio sigep documention.
![Screen Shot 2020-02-20 at 10 34 54 PM](https://user-images.githubusercontent.com/16270345/74996052-466e8400-5431-11ea-9d08-0bedf2bfc9b0.png)
