### PR TITLE
fix fatal error when trying to log Correios response and dv = 0

### DIFF
--- a/src/PhpSigep/Services/Real/GeraDigitoVerificadorEtiquetas.php
+++ b/src/PhpSigep/Services/Real/GeraDigitoVerificadorEtiquetas.php
@@ -35,7 +35,7 @@ class GeraDigitoVerificadorEtiquetas
         $result = new Result();
         try {
             $soapReturn = SoapClientFactory::getSoapClient()->geraDigitoVerificadorEtiquetas($soapArgs);
-            if ($soapReturn && is_object($soapReturn) && $soapReturn->return) {
+            if ($soapReturn && is_object($soapReturn) && isset($soapReturn->return)) {
                 if (!is_array($soapReturn->return)) {
                     $soapReturn->return = (array)$soapReturn->return;
                 }

--- a/src/PhpSigep/Services/Real/GeraDigitoVerificadorEtiquetas.php
+++ b/src/PhpSigep/Services/Real/GeraDigitoVerificadorEtiquetas.php
@@ -46,8 +46,9 @@ class GeraDigitoVerificadorEtiquetas
                 $result->setResult($etiquetas);
             } else {
                 $result->setErrorCode(0);
-                $result->setErrorMsg('A resposta do Correios não está no formato esperado. Resposta recebida: "' .
-                    $soapReturn . '"');
+                $result->setErrorMsg('A resposta do Correios não está no formato esperado. Etiqueta: '
+                    . json_encode($soapArgs['etiquetas'])
+                    . ' Resposta recebida: "' . json_encode($soapReturn) . '"');
             }
         } catch (\Exception $e) {
             if ($e instanceof \SoapFault) {


### PR DESCRIPTION
Fixes:

1. Fatal error when trying to log the Correios response:

```
services-sigep.ERROR: [createVerificationCode] Error in GerarDigitoVerificador WS,
                 code: 0
                 message: Object of class stdClass could not be converted to string
```

Caused by: _soapReturn is an object_
https://github.com/TiendaNube/php-sigep/blob/636bdece6251efc6bf547b7a0a43a6b99b3d1683/src/PhpSigep/Services/Real/GeraDigitoVerificadorEtiquetas.php#L51


2. Fix the success condition, the _$soapReturn->return_ is a **number** and could be **0** value:

Example: `<etiquetas>PW33914865BR</etiquetas>`

![image](https://user-images.githubusercontent.com/8443668/75606490-19bf0a00-5acc-11ea-8ad6-47e0a076a205.png)
