### PR TITLE
Adiciona campo identificação (cpf/cnpj) ao modelo "Destinatario".

### DIFF
--- a/src/PhpSigep/Model/Destinatario.php
+++ b/src/PhpSigep/Model/Destinatario.php
@@ -133,6 +133,13 @@ class Destinatario extends AbstractModel
     protected $ddd;
 
     /**
+     * Identificacao do destinatario (CPF/CNPJ).
+     * Max length: 14
+     * @var string
+     */
+    protected $identificacao;
+
+    /**
      * @return string
      */
     public function getCelular()
@@ -323,6 +330,23 @@ class Destinatario extends AbstractModel
     public function setDdd($ddd)
     {
         $this->ddd = $ddd;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIdentificacao()
+    {
+        return $this->identificacao;
+    }
+
+    /**
+     * @param int $identificacao
+     */
+    public function setIdentificacao($identificacao)
+    {
+        $this->identificacao = $identificacao;
         return $this;
     }
 }

--- a/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
+++ b/src/PhpSigep/Services/Real/FecharPreListaDePostagem.php
@@ -147,6 +147,9 @@ class FecharPreListaDePostagem
         $writer->startElement('email_remetente');
         $writer->writeCdata($this->_($data->getRemetente()->getEmail(), 50));
         $writer->endElement();
+        $writer->startElement('cpf_cnpj_remetente');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $data->getRemetente()->getIdentificacao()), 14));
+        $writer->endElement();
         $writer->endElement();
     }
 
@@ -214,6 +217,9 @@ class FecharPreListaDePostagem
         $writer->endElement();
         $writer->startElement('numero_end_destinatario');
         $writer->writeCdata($this->_($destinatario->getNumero(), 5));
+        $writer->endElement();
+        $writer->startElement('cpf_cnpj_destinatario');
+        $writer->writeCdata($this->_(preg_replace('/[^\d]/', '', $destinatario->getIdentificacao()), 14));
         $writer->endElement();
         $writer->endElement();
     }


### PR DESCRIPTION
Essa implementação tem como objetivo atender a uma alteração que ocorrerá no sistema do Correios, tornando obrigatório, a partir do dia 01/01/2022, o envio do cpf/cnpj do destinatário para encomendas que acompanham nota fiscal.

Essa alteração não torna o campo obrigatório no contexto da biblioteca `php-sigep` (o que, assim sendo, não implicará em breaking changes), mas permite que os serviços e outros códigos que fazem uso da mesma possam exigir os campo nas suas apis/interfaces, fazendo valer a exigência dos correios.

Essa alteração considerou a [implementação](https://github.com/stavarengo/php-sigep/commit/31da29d6163b007f8dfb774a976b1b43de76549e) realizada na biblioteca original [stavarengo/php-sigep](https://github.com/stavarengo/php-sigep) como referência.